### PR TITLE
Fix System.ArgumentException: An item with the same key has already been added. Key: LastExecution

### DIFF
--- a/src/CosmosDbConnection.cs
+++ b/src/CosmosDbConnection.cs
@@ -359,7 +359,7 @@ namespace Hangfire.Azure
 
             foreach (Hash source in sources)
             {
-                Hash hash = hashes.SingleOrDefault(h => h.Field == source.Field);
+                Hash hash = hashes.FirstOrDefault(h => h.Field == source.Field);
                 if (hash == null)
                 {
                     data.Items.Add(source);

--- a/src/CosmosDbConnection.cs
+++ b/src/CosmosDbConnection.cs
@@ -333,7 +333,8 @@ namespace Hangfire.Azure
                 .Where(h => h.DocumentType == DocumentTypes.Hash && h.Key == key)
                 .Select(h => new { h.Field, h.Value })
                 .ToQueryResult()
-                .ToDictionary(h => h.Field, h => h.Value);
+                .GroupBy(h => h.Field, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(hg => hg.Key, hg => hg.First().Value);
         }
 
         public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)

--- a/src/CosmosDbWriteOnlyTransaction.cs
+++ b/src/CosmosDbWriteOnlyTransaction.cs
@@ -351,7 +351,7 @@ namespace Hangfire.Azure
 
                 foreach (Hash source in sources)
                 {
-                    Hash hash = hashes.SingleOrDefault(h => h.Field == source.Field);
+                    Hash hash = hashes.FirstOrDefault(h => h.Field == source.Field);
                     if (hash == null)
                     {
                         data.Items.Add(source);


### PR DESCRIPTION
Hi @imranmomin  appreciate it if you could spend sometimes to look at my PR for this issue
https://github.com/imranmomin/Hangfire.AzureCosmosDb/issues/21