### PR TITLE
Fix issue where expireDocuments stored procedure wouldn't run

### DIFF
--- a/src/StoredProcedure/expireDocuments.js
+++ b/src/StoredProcedure/expireDocuments.js
@@ -10,8 +10,9 @@ function expireDocument(query, expireOn) {
     if (query === undefined || query === null) {
         throw new Error("query is either empty or null");
     }
-    query = `${query} AND (NOT IS_DEFINED(doc.expire_on) OR doc.expire_on !== ${expireOn})`;
+    query = `${query} AND (NOT IS_DEFINED(doc.expire_on) OR doc.expire_on != ${expireOn})`;
     response.setBody(responseBody);
+    tryQueryAndUpdate();
     function tryQueryAndUpdate(continuation) {
         let feedOptions = {
             continuation: continuation,

--- a/src/StoredProcedure/expireDocuments.ts
+++ b/src/StoredProcedure/expireDocuments.ts
@@ -17,11 +17,12 @@ function expireDocument(query: string, expireOn: number) {
     }
 
     // append the query to filter by expire_on is not defined or less than $expireOn
-    query = `${query} AND (NOT IS_DEFINED(doc.expire_on) OR doc.expire_on !== ${expireOn})`;
+    query = `${query} AND (NOT IS_DEFINED(doc.expire_on) OR doc.expire_on != ${expireOn})`;
 
     // default response
     response.setBody(responseBody);
 
+    tryQueryAndUpdate();
     // Recursively runs the query w/ support for continuation tokens.
     // Calls tryUpdate(documents) as soon as the query returns documents.
     function tryQueryAndUpdate(continuation?: string) {


### PR DESCRIPTION
The query syntax was wrong (!== isn't valid SQL), and the tryQueryAndUpdate function was never actually executed