### PR TITLE
Overload for CosmosDbStorage constructor

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,70 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ develop ]
+  schedule:
+    - cron: '18 17 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/src/CosmosDbConnection.cs
+++ b/src/CosmosDbConnection.cs
@@ -335,7 +335,8 @@ namespace Hangfire.Azure
                 .Where(h => h.DocumentType == DocumentTypes.Hash && h.Key == key)
                 .Select(h => new { h.Field, h.Value })
                 .ToQueryResult()
-                .ToDictionary(h => h.Field, h => h.Value);
+                .GroupBy(h => h.Field, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(hg => hg.Key, hg => hg.First().Value);
         }
 
         public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)
@@ -360,7 +361,7 @@ namespace Hangfire.Azure
 
             foreach (Hash source in sources)
             {
-                Hash hash = hashes.SingleOrDefault(h => h.Field == source.Field);
+                Hash hash = hashes.FirstOrDefault(h => h.Field == source.Field);
                 if (hash == null)
                 {
                     data.Items.Add(source);

--- a/src/CosmosDbStorage.cs
+++ b/src/CosmosDbStorage.cs
@@ -58,6 +58,7 @@ namespace Hangfire.Azure
             options.ApplicationName = "Hangfire";
             options.Serializer = new CosmosJsonSerializer(settings);
             Client = new CosmosClient(url, authSecret, options);
+            Initialize();
         }
 
 
@@ -73,6 +74,7 @@ namespace Hangfire.Azure
         {
             Client = cosmosClient;
             Client.ClientOptions.Serializer = new CosmosJsonSerializer(settings);
+            Initialize();
         }
 
         private CosmosDbStorage(string database, string collection, CosmosDbStorageOptions storageOptions = null)
@@ -83,7 +85,6 @@ namespace Hangfire.Azure
 
             JobQueueProvider provider = new JobQueueProvider(this);
             QueueProviders = new PersistentJobQueueProviderCollection(provider);
-            Initialize();
         }
 
         /// <summary>

--- a/src/CosmosDbWriteOnlyTransaction.cs
+++ b/src/CosmosDbWriteOnlyTransaction.cs
@@ -356,7 +356,7 @@ namespace Hangfire.Azure
 
                 foreach (Hash source in sources)
                 {
-                    Hash hash = hashes.SingleOrDefault(h => h.Field == source.Field);
+                    Hash hash = hashes.FirstOrDefault(h => h.Field == source.Field);
                     if (hash == null)
                     {
                         data.Items.Add(source);


### PR DESCRIPTION
Overload CosmosDbStorage constructor. New  version accept an instance of CosmosClient, it give the opportunity of create CosmosClient in other way, for example with role-based access as in this example https://docs.microsoft.com/en-gb/azure/cosmos-db/how-to-setup-rbac#in-net. 