### PR TITLE
Query performances

### DIFF
--- a/src/CosmosDbStorage.cs
+++ b/src/CosmosDbStorage.cs
@@ -259,7 +259,9 @@ public sealed class CosmosDbStorage : JobStorage
         Collection<CompositePath> compositeIndexes = new ()
         {
             new CompositePath { Path = "/name", Order = CompositePathSortOrder.Ascending },
-            new CompositePath { Path = "/created_on", Order = CompositePathSortOrder.Ascending }
+            new CompositePath { Path = "/created_on", Order = CompositePathSortOrder.Ascending },
+            new CompositePath { Path = "/type", Order = CompositePathSortOrder.Ascending },
+            new CompositePath { Path = "/score", Order = CompositePathSortOrder.Ascending }
         };
 
         properties.IndexingPolicy.CompositeIndexes.Add(compositeIndexes);

--- a/src/ExpirationManager.cs
+++ b/src/ExpirationManager.cs
@@ -42,7 +42,7 @@ internal class ExpirationManager : IServerComponent
 
 				logger.Trace($"Removing outdated records from the [{type}] table.");
 
-				string query = $"SELECT * FROM doc WHERE IS_DEFINED(doc.expire_on) AND doc.expire_on < {expireOn}";
+				string query = $"SELECT * FROM doc WHERE doc.expire_on < {expireOn}";
 
 				// remove only the aggregate counters when the type is Counter
 				if (type == DocumentTypes.Counter) query += $" AND doc.counterType = {(int)CounterTypes.Aggregate}";


### PR DESCRIPTION
After deploying our application we found some Hangfire collections with lot of 429's errors. Our DB team has suggested the following changes:

**1. Below query would benefit from adding the following composite index on both collections: ["\/type ASC","\/key ASC","\/score ASC"]**

> {"query":"SELECT TOP 1000.2 VALUE r1['p2']\nFROM r1\nWHERE ((r1.p1 = @param1) AND (r1.p3 BETWEEN @param2 AND @param3))\nORDER BY r1.p3","parameters":[{"name":"@param1","value":"str1"},{"name":"@param2","value":0},{"name":"@param3","value":1700100000}]}

**2. We have observed that status 429 error code on below query** 

> **{"query":"SELECT * FROM doc WHERE IS_DEFINED(doc.expire_on) AND doc.expire_on < 1694454340","parameters":[]}**

As recommended by Microsoft can this be rewritten more optimally as below:

> {"query":"SELECT * FROM doc WHERE doc.expire_on < 1694454340","parameters":[]}

In the following pictures you can see the results of applying these changes:

![image](https://github.com/imranmomin/Hangfire.AzureCosmosDb/assets/22416893/4038e428-87ca-498d-b34b-cff9ae6d934c)

![image](https://github.com/imranmomin/Hangfire.AzureCosmosDb/assets/22416893/e3a9d358-ab49-42ea-8434-f6535f9125c7)
