### PR TITLE
feat: Hangfire 1.8.x

### DIFF
--- a/src/CosmosDbStorage.cs
+++ b/src/CosmosDbStorage.cs
@@ -77,6 +77,35 @@ public sealed class CosmosDbStorage : JobStorage
         Client = cosmosClient;
     }
 
+    /// <summary>
+    /// Enabled Hangfire features.
+    /// </summary>
+    public ReadOnlyDictionary<string, bool> Features { get; set; } = new ReadOnlyDictionary<string, bool>(
+        new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            {JobStorageFeatures.ExtendedApi, true},
+            {JobStorageFeatures.JobQueueProperty, true},
+            {JobStorageFeatures.Connection.BatchedGetFirstByLowest, true},
+            {JobStorageFeatures.Connection.GetUtcDateTime, false},
+            {JobStorageFeatures.Connection.GetSetContains, true},
+            {JobStorageFeatures.Connection.LimitedGetSetCount, true},
+            {JobStorageFeatures.Transaction.AcquireDistributedLock, true},
+            {JobStorageFeatures.Transaction.CreateJob, true},
+            {JobStorageFeatures.Transaction.SetJobParameter, true},
+            {JobStorageFeatures.Monitoring.DeletedStateGraphs, true},
+            {JobStorageFeatures.Monitoring.AwaitingJobs, true},
+        });
+
+    public override bool HasFeature(string featureId)
+    {
+        if (featureId == null)
+            throw new ArgumentNullException(nameof(featureId));
+
+        return Features.TryGetValue(featureId, out bool isSupported)
+            ? isSupported
+            : base.HasFeature(featureId);
+    }
+
     private CosmosDbStorage(string databaseName, string containerName, CosmosDbStorageOptions? storageOptions = null)
     {
         if (string.IsNullOrEmpty(databaseName))

--- a/src/Hangfire.AzureCosmosDB.csproj
+++ b/src/Hangfire.AzureCosmosDB.csproj
@@ -65,10 +65,10 @@
 
     <ItemGroup>
         <PackageReference Include="Hangfire.Core" Version="1.7.29" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.27.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" Condition="$(MSBuildProjectExtension) == '.csproj'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Hangfire.AzureCosmosDB.csproj
+++ b/src/Hangfire.AzureCosmosDB.csproj
@@ -64,7 +64,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hangfire.Core" Version="1.7.29" />
+        <PackageReference Include="Hangfire.Core" Version="1.8.14" />
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/test/CosmosDbConnectionFacts.cs
+++ b/test/CosmosDbConnectionFacts.cs
@@ -196,7 +196,6 @@ public class CosmosDbConnectionFacts : IClassFixture<ContainerFixture>
 		Assert.Null(job);
 	}
 
-
 	[Fact]
 	public void GetJobData_ReturnsNull_WhenThereIsNoSuchJob()
 	{
@@ -1214,8 +1213,8 @@ public class CosmosDbConnectionFacts : IClassFixture<ContainerFixture>
 			distributedLock.Dispose();
 		});
 
-		// lets set the range
-		Task.Run(() => { connection.SetRangeInHash("some-hash", new Dictionary<string, string?> { { "key1", "VALUE-1" } }); }).Wait();
+        // lets set the range
+        Task.Run(() => connection.SetRangeInHash("some-hash", new Dictionary<string, string?> { { "key1", "VALUE-1" } })).Wait();
 
 		//assert
 		QueryRequestOptions queryRequestOptions = new() { PartitionKey = PartitionKeys.Hash };
@@ -1939,7 +1938,6 @@ public class CosmosDbConnectionFacts : IClassFixture<ContainerFixture>
 		Assert.NotNull(@lock);
 		@lock.Dispose();
 	}
-
 
 #pragma warning disable xUnit1013
 	// ReSharper disable once MemberCanBePrivate.Global

--- a/test/CosmosDbStorageFacts.cs
+++ b/test/CosmosDbStorageFacts.cs
@@ -24,10 +24,10 @@ public class CosmosDbStorageFacts
 			.Build();
 
 		IConfigurationSection section = configuration.GetSection("CosmosDB");
-		url = section.GetValue<string>("Url");
-		secret = section.GetValue<string>("Secret");
-		database = section.GetValue<string>("Database");
-		container = section.GetValue<string>("Container");
+		url = section.GetValue<string>("Url") ?? string.Empty;
+		secret = section.GetValue<string>("Secret") ?? string.Empty;
+		database = section.GetValue<string>("Database") ?? string.Empty;
+		container = section.GetValue<string>("Container") ?? string.Empty;
 	}
 
 	[Fact]
@@ -117,7 +117,7 @@ public class CosmosDbStorageFacts
 
 	private CosmosDbStorage CreateSutWithCosmosClient()
 	{
-		var cosmosClient = new CosmosClient(url, secret);
+        var cosmosClient = new CosmosClient(url, secret);
 		return  new(cosmosClient, database, container);
 	}
 }

--- a/test/CosmosDbStorageFeatureFacts.cs
+++ b/test/CosmosDbStorageFeatureFacts.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using Hangfire.Azure.Tests.Fixtures;
+using Hangfire.Common;
+using Hangfire.Storage;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Hangfire.Azure.Tests;
+
+public class CosmosDbStorageFeatureFacts : IClassFixture<ContainerFixture>
+{
+    private ContainerFixture ContainerFixture { get; }
+
+    private CosmosDbStorage Storage { get; }
+
+    public CosmosDbStorageFeatureFacts(ContainerFixture containerFixture, ITestOutputHelper testOutputHelper)
+    {
+        ContainerFixture = containerFixture;
+        Storage = containerFixture.Storage;
+
+        ContainerFixture.SetupLogger(testOutputHelper);
+    }    
+
+    [Fact]
+    public void AddOrUpdate_ThrowsAnException_WhenJobQueueIsSet_WhenStorageFeaturesDoesNotSupportIt()
+    {
+        // Arrange
+        Storage.Features = new ReadOnlyDictionary<string, bool>(new Dictionary<string, bool>
+        {
+            { JobStorageFeatures.JobQueueProperty, false },
+        });
+
+        Job job = Job.FromExpression(() => Method(), "some-queue");
+        RecurringJobManager manager = new (Storage);
+
+        // Act & Assert
+        Assert.Throws<NotSupportedException>(() => manager.AddOrUpdate("recurring-job-id", job, Cron.Minutely()));
+    }
+
+    [Fact]
+    public void AddOrUpdate_NoException_WhenJobQueueIsSet_WhenStorageFeaturesDoesSupportIt()
+    {
+        // Arrange
+        Storage.Features = new ReadOnlyDictionary<string, bool>(new Dictionary<string, bool>
+        {
+            { JobStorageFeatures.JobQueueProperty, true },
+        });
+
+        Job job = Job.FromExpression(() => Method(), "some-queue");
+        RecurringJobManager manager = new (Storage);
+
+        // Act & Assert
+        try
+        {
+            manager.AddOrUpdate("recurring-job-id", job, Cron.Minutely());
+        }
+        catch
+        {
+            Assert.Fail("Expected no exception for feature JobStorageFeatures.JobQueueProperty set to true.");
+        }
+    }
+
+    [SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public static void Method() { }
+}

--- a/test/Fixtures/ContainerFixture.cs
+++ b/test/Fixtures/ContainerFixture.cs
@@ -24,10 +24,10 @@ public class ContainerFixture : IDisposable
 			.Build();
 
 		IConfigurationSection section = configuration.GetSection("CosmosDB");
-		string url = section.GetValue<string>("Url");
-		string secret = section.GetValue<string>("Secret");
-		string database = section.GetValue<string>("Database");
-		string container = section.GetValue<string>("Container");
+		string url = section.GetValue<string>("Url") ?? string.Empty;
+		string secret = section.GetValue<string>("Secret") ?? string.Empty;
+		string database = section.GetValue<string>("Database") ?? string.Empty;
+		string container = section.GetValue<string>("Container") ?? string.Empty;
 
 		CosmosDbStorageOptions option = new()
 		{
@@ -54,7 +54,8 @@ public class ContainerFixture : IDisposable
 
 	public void Dispose()
 	{
-		if (disposed) return;
+        if (disposed)
+            return;
 		disposed = true;
 
 		Clean();
@@ -64,10 +65,7 @@ public class ContainerFixture : IDisposable
 	{
 		private readonly ITestOutputHelper testOutputHelper;
 
-		public TestLogger(ITestOutputHelper testOutputHelper)
-		{
-			this.testOutputHelper = testOutputHelper;
-		}
+		public TestLogger(ITestOutputHelper testOutputHelper) => this.testOutputHelper = testOutputHelper;
 
 		public ILog GetLogger(string name) => new TestLog(testOutputHelper);
 	}
@@ -76,14 +74,12 @@ public class ContainerFixture : IDisposable
 	{
 		private readonly ITestOutputHelper? testOutputHelper;
 
-		public TestLog(ITestOutputHelper testOutputHelper)
-		{
-			this.testOutputHelper = testOutputHelper;
-		}
+        public TestLog(ITestOutputHelper testOutputHelper) => this.testOutputHelper = testOutputHelper;
 
-		public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception = null)
+        public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception = null)
 		{
-			if (messageFunc != null && testOutputHelper != null) testOutputHelper.WriteLine("[{0:O}] - [{1}] - {2} {3}", DateTime.UtcNow, logLevel, messageFunc(), exception?.Message);
+            if (messageFunc != null && testOutputHelper != null)
+                testOutputHelper.WriteLine("[{0:O}] - [{1}] - {2} {3}", DateTime.UtcNow, logLevel, messageFunc(), exception?.Message);
 			return true;
 		}
 	}

--- a/test/Hangfire.AzureCosmosDb.Tests.csproj
+++ b/test/Hangfire.AzureCosmosDb.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/test/Hangfire.AzureCosmosDb.Tests.csproj
+++ b/test/Hangfire.AzureCosmosDb.Tests.csproj
@@ -12,18 +12,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="Moq" Version="4.18.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Updated dependencies in general but especially for
- Hangfire 1.8.14
- .NET 8 (test project)

Added code for the handling of JobStorageFeatures
- the set of features for CosmosDbStorage is taken from the Hangfire.Mongo CosmosDB implementation

Added tests for
- a feature called JobStorageFeature.JobQueueProperty